### PR TITLE
Show 7-day window in status bar (text + color source)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,36 @@
           ],
           "default": "auto",
           "description": "Clock format for reset times in the usage panel."
+        },
+        "claude-usage-monitor.statusBar": {
+          "type": "string",
+          "enum": [
+            "5h",
+            "7d",
+            "both"
+          ],
+          "enumDescriptions": [
+            "Show 5-hour window utilization and reset countdown (default)",
+            "Show 7-day window utilization and reset countdown",
+            "Show both windows; countdown follows the 5-hour reset"
+          ],
+          "default": "5h",
+          "description": "Which quota windows to display in the status bar text."
+        },
+        "claude-usage-monitor.statusBarColorFrom": {
+          "type": "string",
+          "enum": [
+            "5h",
+            "7d",
+            "max"
+          ],
+          "enumDescriptions": [
+            "Color the status bar by the 5-hour window only",
+            "Color the status bar by the 7-day window only",
+            "Color the status bar by whichever window's utilization is higher (default)"
+          ],
+          "default": "max",
+          "description": "Which window's utilization drives the status bar background color (≥60% warning, ≥80% error)."
         }
       }
     },

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,5 +1,21 @@
 import * as vscode from 'vscode';
-import { UsageData } from './types';
+import { QuotaBucket, UsageData } from './types';
+
+type StatusBarMode = '5h' | '7d' | 'both';
+type ColorSource   = '5h' | '7d' | 'max';
+
+interface StatusBarConfig {
+	mode:        StatusBarMode;
+	colorSource: ColorSource;
+}
+
+function readConfig(): StatusBarConfig {
+	const cfg = vscode.workspace.getConfiguration('claude-usage-monitor');
+	return {
+		mode:        cfg.get<StatusBarMode>('statusBar', '5h'),
+		colorSource: cfg.get<ColorSource>('statusBarColorFrom', 'max'),
+	};
+}
 
 function timeAgo(date: Date): string {
 	const sec = Math.floor((Date.now() - date.getTime()) / 1000);
@@ -27,16 +43,70 @@ function utilizationColor(pct: number): vscode.ThemeColor | undefined {
 	return undefined;
 }
 
+function pickColorPct(
+	colorSource: ColorSource,
+	fh: QuotaBucket,
+	sd: QuotaBucket | null,
+): number {
+	switch (colorSource) {
+		case '5h':  return fh.utilization;
+		case '7d':  return sd ? sd.utilization : fh.utilization;
+		case 'max': return sd ? Math.max(fh.utilization, sd.utilization) : fh.utilization;
+	}
+}
+
+function renderText(
+	mode: StatusBarMode,
+	fh: QuotaBucket,
+	sd: QuotaBucket | null,
+	withWarning: boolean,
+): string {
+	const suffix = withWarning ? ' $(warning)' : '';
+	const fhPct  = fh.utilization.toFixed(0);
+	const fhTime = formatTimeRemaining(fh.resetsAt);
+
+	if (mode === '7d' && sd) {
+		const sdPct  = sd.utilization.toFixed(0);
+		const sdTime = formatTimeRemaining(sd.resetsAt);
+		return `$(claude-icon) 7d ${sdPct}% · ${sdTime}${suffix}`;
+	}
+
+	if (mode === 'both' && sd) {
+		const sdPct = sd.utilization.toFixed(0);
+		return `$(claude-icon) 5h ${fhPct}% (${fhTime}) · 7d ${sdPct}%${suffix}`;
+	}
+
+	// '5h' mode, or '7d'/'both' fallback when sevenDay is missing
+	return `$(claude-icon) ${fhPct}% · ${fhTime}${suffix}`;
+}
+
 export class StatusBarManager {
 	private item: vscode.StatusBarItem;
+	private lastData:  UsageData | null = null;
+	private lastError: string | null    = null;
+	private configSub: vscode.Disposable;
 
 	constructor() {
 		this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
 		this.item.command = 'claude-usage-monitor.showPopup';
 		this.item.show();
+
+		this.configSub = vscode.workspace.onDidChangeConfiguration((e) => {
+			if (
+				e.affectsConfiguration('claude-usage-monitor.statusBar') ||
+				e.affectsConfiguration('claude-usage-monitor.statusBarColorFrom')
+			) {
+				if (this.lastData) {
+					this.update(this.lastData, this.lastError);
+				}
+			}
+		});
 	}
 
 	public update(data: UsageData, error: string | null = null) {
+		this.lastData  = data;
+		this.lastError = error;
+
 		const fh = data.fiveHour;
 		if (!fh) {
 			this.item.text = '$(claude-icon) No data';
@@ -45,18 +115,16 @@ export class StatusBarManager {
 			return;
 		}
 
-		const pct = fh.utilization;
-		const timeLeft = formatTimeRemaining(fh.resetsAt);
+		const { mode, colorSource } = readConfig();
+		const sd = data.sevenDay;
+		const eu = data.extraUsage;
 
-		this.item.text = error
-			? `$(claude-icon) ${pct.toFixed(0)}% · ${timeLeft} $(warning)`
-			: `$(claude-icon) ${pct.toFixed(0)}% · ${timeLeft}`;
+		this.item.text = renderText(mode, fh, sd, !!error);
+
+		const colorPct = pickColorPct(colorSource, fh, sd);
 		this.item.backgroundColor = error
 			? new vscode.ThemeColor('statusBarItem.warningBackground')
-			: utilizationColor(pct);
-
-		const sd  = data.sevenDay;
-		const eu  = data.extraUsage;
+			: utilizationColor(colorPct);
 
 		const bar = (p: number) => {
 			const filled = Math.round(Math.min(p, 100) / 10);
@@ -68,8 +136,8 @@ export class StatusBarManager {
 			`$(claude-icon) **Claude Usage**`,
 			`---`,
 			`**5-Hour Window**`,
-			`\`${bar(pct)}\``,
-			`↻ Resets in **${timeLeft}**`,
+			`\`${bar(fh.utilization)}\``,
+			`↻ Resets in **${formatTimeRemaining(fh.resetsAt)}**`,
 		];
 
 		if (sd) {
@@ -144,5 +212,6 @@ export class StatusBarManager {
 
 	public dispose() {
 		this.item.dispose();
+		this.configSub.dispose();
 	}
 }


### PR DESCRIPTION
Closes #6.

## Summary

Adds two configuration options so the status bar reflects the **7-day** window, not only the 5-hour one. With the new defaults, the bar's background color escalates as soon as *either* window crosses the 60% / 80% threshold — so weekly pressure no longer goes silent when the 5h window is calm.

### New settings

| Key | Values | Default | Effect |
|---|---|---|---|
| `claude-usage-monitor.statusBar` | `"5h"` / `"7d"` / `"both"` | `"5h"` | Which window(s) appear in the status bar text |
| `claude-usage-monitor.statusBarColorFrom` | `"5h"` / `"7d"` / `"max"` | `"max"` | Which utilization drives the background color |

### Text formats

- `5h` (default, unchanged): `☁ X% · Yh Zm`
- `7d`: `☁ 7d X% · <reset>`
- `both`: `☁ 5h X% (Yh Zm) · 7d N%`

The 5-hour countdown is placed in parens **next to** the 5h percentage in `both` mode, so it's unambiguous which window the time refers to. The 7-day countdown is omitted from the status bar (it's a wide weekday+time string and is still visible in the hover tooltip).

### Color source

| Mode | Logic |
|---|---|
| `5h` | `utilizationColor(fh.utilization)` — current behavior |
| `7d` | `utilizationColor(sd.utilization)`, fallback to 5h if 7d is null |
| `max` (default) | `utilizationColor(max(fh, sd))`, fallback to 5h if 7d is null |

### Live config updates

`StatusBarManager` now subscribes to `onDidChangeConfiguration` and re-renders immediately when either of the new keys changes — no need to wait for the next 2-minute poll. The subscription is disposed in `dispose()`.

## Notes / open questions

- Default for `statusBar` is kept at `"5h"` so existing users see no text change. Only the color behavior changes (to `colorFrom: "max"`), which I think is the intent of the issue — but happy to flip the color default back to `"5h"` if you'd prefer truly zero-change defaults.
- I did not bump the `version` in `package.json` — that's yours to pick.
- Hover tooltip and side panel are untouched; they already show all windows.

## Test plan

- [x] `npm run check-types` — clean
- [x] `npm run lint` — clean
- [x] `npm run package` (production esbuild) — clean
- [x] Built a VSIX with `vsce package`, installed locally, verified:
  - Default settings: text unchanged; background color now responds to 7d (verified by inspecting the code paths — my own 7d is at 0% so I couldn't see it flip naturally, but the wiring matches the existing 5h color path)
  - `statusBar: "7d"` → text switches to `7d X% · <reset>`
  - `statusBar: "both"` → text becomes `5h X% (Yh Zm) · 7d Y%`
  - Settings changes take effect immediately without reload