### PR TITLE
fix: stop hammering the rate limited usage endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ A VS Code extension that displays real-time Claude Code quota usage via the Anth
 
 ## How It Works
 
-The extension reads the OAuth token from `~/.claude/.credentials.json` (the same file Claude Code uses) and calls `GET https://api.anthropic.com/api/oauth/usage` every 30 seconds. No local JSONL parsing or file watching.
+The extension reads the OAuth token from `~/.claude/.credentials.json` (the same file Claude Code uses) and calls `GET https://api.anthropic.com/api/oauth/usage` on an interval (`claude-usage-monitor.refreshInterval`, default 300 s, minimum 60 s), only while a window is focused, with one cache shared across windows. No local JSONL parsing or file watching.
 
 ## Architecture
 
 ```
 src/
-  extension.ts      # Activation, 30s polling loop, command registration
+  extension.ts      # Activation, polling loop (configurable interval), command registration
   usageClient.ts    # Credentials reading + HTTPS call to /api/oauth/usage
   statusBar.ts      # Status bar item: "69% · 2h 14m" with color coding
   sessionPopover.ts # Webview panel with progress bars for all quota windows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ A VS Code extension that displays real-time Claude Code quota usage via the Anth
 
 ## How It Works
 
-The extension reads the OAuth token from `~/.claude/.credentials.json` (the same file Claude Code uses) and calls `GET https://api.anthropic.com/api/oauth/usage` on an interval (`claude-usage-monitor.refreshInterval`, default 300 s, minimum 60 s), only while a window is focused, with one cache shared across windows. No local JSONL parsing or file watching.
+The extension reads the OAuth token from `~/.claude/.credentials.json` (the same file Claude Code uses) and calls `GET https://api.anthropic.com/api/oauth/usage` on an interval (`claude-usage-monitor.refreshInterval`, default 120 s, minimum 60 s), only while a window is focused, with one cache shared across windows. No local JSONL parsing or file watching.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A VS Code extension that shows your real-time Claude Code quota usage directly i
 
 ## How It Works
 
-The extension authenticates using the OAuth token that Claude Code already stores locally at `~/.claude/.credentials.json`. It polls `GET https://api.anthropic.com/api/oauth/usage` every 5 minutes by default (only when the window is focused) and displays the results without any additional login or configuration.
+The extension authenticates using the OAuth token that Claude Code already stores locally at `~/.claude/.credentials.json`. It polls `GET https://api.anthropic.com/api/oauth/usage` every 2 minutes by default (only when the window is focused) and displays the results without any additional login or configuration.
 
 The interval is configurable with `claude-usage-monitor.refreshInterval` (seconds, minimum 60). All windows share one cache, so the interval applies per machine. If the status bar shows `HTTP 429 — Rate limited`, raise it: the usage endpoint has a small hourly budget per account, and every open VS Code window, Claude Code session and other usage tool on the machine draws from the same budget.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A VS Code extension that shows your real-time Claude Code quota usage directly i
 
 ## How It Works
 
-The extension authenticates using the OAuth token that Claude Code already stores locally at `~/.claude/.credentials.json`. It polls `GET https://api.anthropic.com/api/oauth/usage` every 2 minutes (only when the window is focused) and displays the results without any additional login or configuration.
+The extension authenticates using the OAuth token that Claude Code already stores locally at `~/.claude/.credentials.json`. It polls `GET https://api.anthropic.com/api/oauth/usage` every 5 minutes by default (only when the window is focused) and displays the results without any additional login or configuration.
+
+The interval is configurable with `claude-usage-monitor.refreshInterval` (seconds, minimum 60). All windows share one cache, so the interval applies per machine. If the status bar shows `HTTP 429 — Rate limited`, raise it: the usage endpoint has a small hourly budget per account, and every open VS Code window, Claude Code session and other usage tool on the machine draws from the same budget.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A VS Code extension that shows your real-time Claude Code quota usage directly i
 
 The extension authenticates using the OAuth token that Claude Code already stores locally at `~/.claude/.credentials.json`. It polls `GET https://api.anthropic.com/api/oauth/usage` every 2 minutes by default (only when the window is focused) and displays the results without any additional login or configuration.
 
+When the API answers `HTTP 429` it also says how long to wait, and the extension waits exactly that long. The block is stored in the cache all windows share, so one window being told to back off stops the others too.
+
 The interval is configurable with `claude-usage-monitor.refreshInterval` (seconds, minimum 60). All windows share one cache, so the interval applies per machine. If the status bar shows `HTTP 429 — Rate limited`, raise it: the usage endpoint has a small hourly budget per account, and every open VS Code window, Claude Code session and other usage tool on the machine draws from the same budget.
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -146,10 +146,10 @@
         },
         "claude-usage-monitor.refreshInterval": {
           "type": "number",
-          "default": 300,
+          "default": 120,
           "minimum": 60,
           "maximum": 3600,
-          "markdownDescription": "How often to poll the usage API, in seconds (default 300, minimum 60). Polling only happens while a VS Code window is focused, and all windows share one cache so the interval applies per machine, not per window. Raise this if you see `HTTP 429 — Rate limited` in the status bar: the usage endpoint has a small hourly budget per account."
+          "markdownDescription": "How often to poll the usage API, in seconds (default 120, minimum 60). Polling only happens while a VS Code window is focused, and all windows share one cache so the interval applies per machine, not per window. Raise this if you see `HTTP 429 — Rate limited` in the status bar: the usage endpoint has a small hourly budget per account."
         },
         "claude-usage-monitor.burnRate": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,13 @@
           "additionalProperties": false,
           "markdownDescription": "Glyphs used by `emoji` mode of `#claude-usage-monitor.statusBarIndicator#`, and by the `{dot}` format token in any mode. Any text works, not just emoji. Keep the glyphs the same width or the bar will shift as the level changes — the emoji-presentation shapes (\ud83d\udfe2 \ud83d\udfe1 \ud83d\udd34 \ud83d\udfe0 \u26a0\ufe0f) are all double-width."
         },
+        "claude-usage-monitor.refreshInterval": {
+          "type": "number",
+          "default": 300,
+          "minimum": 60,
+          "maximum": 3600,
+          "markdownDescription": "How often to poll the usage API, in seconds (default 300, minimum 60). Polling only happens while a VS Code window is focused, and all windows share one cache so the interval applies per machine, not per window. Raise this if you see `HTTP 429 — Rate limited` in the status bar: the usage endpoint has a small hourly budget per account."
+        },
         "claude-usage-monitor.burnRate": {
           "type": "boolean",
           "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { recordHistory } from './history';
 import { UsageData } from './types';
 
 const CONFIG_SECTION           = 'claude-usage-monitor';
-const DEFAULT_POLL_INTERVAL_S  = 300;
+const DEFAULT_POLL_INTERVAL_S  = 120;
 const MIN_POLL_INTERVAL_S      = 60;
 const MAX_POLL_INTERVAL_S      = 3600;
 // The cache is considered fresh for slightly less than one interval, so a

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { fetchUsageData, UsageHttpError } from './usageClient';
+import { fetchUsageData, setUserAgent, UsageHttpError } from './usageClient';
 import { StatusBarManager } from './statusBar';
 import { UsagePanel } from './sessionPopover';
 import { maybeNotify } from './notifications';
@@ -74,6 +74,7 @@ function dropLegacyKeys(memento: vscode.Memento) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
+	setUserAgent(String(context.extension.packageJSON?.version ?? ''));
 	dropLegacyKeys(context.globalState);
 
 	const statusBar = new StatusBarManager();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { fetchUsageData } from './usageClient';
+import { fetchUsageData, UsageHttpError } from './usageClient';
 import { StatusBarManager } from './statusBar';
 import { UsagePanel } from './sessionPopover';
 import { maybeNotify } from './notifications';
@@ -39,6 +39,12 @@ interface CacheEntry {
 	data:      UsageData | null;
 	error:     string | null;
 	fetchedAt: number; // Date.now()
+	/**
+	 * Epoch ms until which the API told us to stay away (`retry-after` on a
+	 * 429). Lives in the shared cache so every window honours one block
+	 * instead of each of them discovering it again.
+	 */
+	blockedUntil?: number;
 }
 
 function reviveCache(raw: CacheEntry | undefined): CacheEntry | null {
@@ -77,6 +83,7 @@ export function activate(context: vscode.ExtensionContext) {
 	let currentError: string | null    = null;
 	let errorCount    = 0;
 	let timer: ReturnType<typeof setTimeout> | null = null;
+	let blockedUntil = 0; // epoch ms, from the API's own retry-after
 	// Read the real state: onDidChangeWindowState only fires on a *change*, so a
 	// window that activates unfocused would otherwise poll forever believing it
 	// is focused. On a machine with several windows open that multiplies every
@@ -101,11 +108,15 @@ export function activate(context: vscode.ExtensionContext) {
 	function scheduleNext() {
 		if (!windowFocused) { return; } // don't poll in background
 
-		// Back off after errors, but never poll faster than the configured interval.
+		// A 429 comes with the exact time to wait. Retrying earlier keeps the
+		// rate limit window saturated, so the block never lifts. Honour it over
+		// both the interval and the backoff.
 		const interval = pollIntervalMs();
-		const delay = errorCount === 0
+		const backoff = errorCount === 0
 			? interval
 			: Math.max(interval, BACKOFF_STEPS_MS[Math.min(errorCount - 1, BACKOFF_STEPS_MS.length - 1)]);
+		const untilUnblocked = blockedUntil - Date.now() + 1_000; // clear the boundary
+		const delay = Math.max(backoff, untilUnblocked);
 
 		timer = setTimeout(async () => {
 			await refresh();
@@ -114,8 +125,18 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	async function refresh() {
-		// Check global cache first — skip fetch if another window just did it
 		const cached = reviveCache(context.globalState.get<CacheEntry>(CACHE_KEY));
+
+		// Another window (or an earlier poll here) was told to back off. Calling
+		// anyway would count against the same account budget and keep the block
+		// alive, so show what we have and wait it out.
+		if (cached?.blockedUntil && cached.blockedUntil > Date.now()) {
+			blockedUntil = cached.blockedUntil;
+			applyState(cached.data, cached.error);
+			return;
+		}
+
+		// Skip the fetch if another window just did it
 		if (cached && (Date.now() - cached.fetchedAt) < cacheTtlMs()) {
 			errorCount = cached.error ? errorCount : 0;
 			applyState(cached.data, cached.error);
@@ -125,13 +146,17 @@ export function activate(context: vscode.ExtensionContext) {
 		try {
 			const data = await fetchUsageData();
 			errorCount = 0;
+			blockedUntil = 0;
 			const entry: CacheEntry = { data, error: null, fetchedAt: Date.now() };
 			await context.globalState.update(CACHE_KEY, entry);
 			applyState(data, null);
 		} catch (err) {
 			errorCount++;
 			const error = err instanceof Error ? err.message : String(err);
+			const retryAfterMs = err instanceof UsageHttpError ? err.retryAfterMs : null;
+			blockedUntil = retryAfterMs === null ? 0 : Date.now() + retryAfterMs;
 			const entry: CacheEntry = { data: null, error, fetchedAt: Date.now() };
+			if (blockedUntil > 0) { entry.blockedUntil = blockedUntil; }
 			await context.globalState.update(CACHE_KEY, entry);
 			applyState(null, error);
 			console.error('[Claude Usage Monitor]', error);
@@ -188,8 +213,11 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const refreshCmd = vscode.commands.registerCommand('claude-usage-monitor.refresh', async () => {
 		if (timer) { clearTimeout(timer); timer = null; }
-		// Force a real fetch by clearing the cache
-		await context.globalState.update(CACHE_KEY, undefined);
+		// Force a real fetch by clearing the cache, unless the API told us to
+		// wait: a manual retry during a block costs quota and extends nothing.
+		const cached = reviveCache(context.globalState.get<CacheEntry>(CACHE_KEY));
+		const stillBlocked = !!cached?.blockedUntil && cached.blockedUntil > Date.now();
+		if (!stillBlocked) { await context.globalState.update(CACHE_KEY, undefined); }
 		await refresh();
 		scheduleNext();
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,7 +77,11 @@ export function activate(context: vscode.ExtensionContext) {
 	let currentError: string | null    = null;
 	let errorCount    = 0;
 	let timer: ReturnType<typeof setTimeout> | null = null;
-	let windowFocused = true;
+	// Read the real state: onDidChangeWindowState only fires on a *change*, so a
+	// window that activates unfocused would otherwise poll forever believing it
+	// is focused. On a machine with several windows open that multiplies every
+	// poll, and the usage endpoint is rate limited per account.
+	let windowFocused = vscode.window.state.focused;
 
 	function applyState(data: UsageData | null, error: string | null) {
 		if (data) { currentData = data; } // keep last good data on error
@@ -134,11 +138,20 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	}
 
-	// On startup: show cached data immediately, then fetch if stale
+	// On startup: show whatever the shared cache holds immediately.
 	const cached = reviveCache(context.globalState.get<CacheEntry>(CACHE_KEY));
 	if (cached) {
 		applyState(cached.data, cached.error);
-		const age = Date.now() - cached.fetchedAt;
+	} else {
+		statusBar.showInitializing();
+	}
+
+	// Only a focused window fetches. Restoring a session opens every window at
+	// once; without this they would all fetch in the same instant, before any of
+	// them has written the shared cache the others check. An unfocused window
+	// stays idle until onDidChangeWindowState reports focus, which refreshes.
+	if (windowFocused) {
+		const age = cached ? Date.now() - cached.fetchedAt : Number.POSITIVE_INFINITY;
 		const ttl = cacheTtlMs();
 		if (age < ttl) {
 			// Cache is fresh — delay first fetch to fill remaining TTL
@@ -148,9 +161,6 @@ export function activate(context: vscode.ExtensionContext) {
 		} else {
 			refresh().then(() => scheduleNext());
 		}
-	} else {
-		statusBar.showInitializing();
-		refresh().then(() => scheduleNext());
 	}
 
 	const onFocus = vscode.window.onDidChangeWindowState((state) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,13 +6,29 @@ import { maybeNotify } from './notifications';
 import { recordHistory } from './history';
 import { UsageData } from './types';
 
-const POLL_INTERVAL_MS = 2  * 60_000; // 2 minutes
-const CACHE_TTL_MS     = 115_000;     // treat cache as fresh if < ~2min old
+const CONFIG_SECTION           = 'claude-usage-monitor';
+const DEFAULT_POLL_INTERVAL_S  = 300;
+const MIN_POLL_INTERVAL_S      = 60;
+const MAX_POLL_INTERVAL_S      = 3600;
+// The cache is considered fresh for slightly less than one interval, so a
+// window whose timer fires a moment early still reuses the previous fetch.
+const CACHE_TTL_SLACK_MS       = 5_000;
 const BACKOFF_STEPS_MS = [
 	4  * 60_000,  // 1st error → wait 4 min
 	8  * 60_000,  // 2nd error → wait 8 min
 	16 * 60_000,  // 3rd+ error → wait 16 min
 ];
+
+/** Poll interval from settings, clamped to the documented range. */
+function pollIntervalMs(): number {
+	const raw = vscode.workspace.getConfiguration(CONFIG_SECTION).get<number>('refreshInterval');
+	const seconds = typeof raw === 'number' && Number.isFinite(raw) ? raw : DEFAULT_POLL_INTERVAL_S;
+	return Math.min(MAX_POLL_INTERVAL_S, Math.max(MIN_POLL_INTERVAL_S, seconds)) * 1000;
+}
+
+function cacheTtlMs(): number {
+	return pollIntervalMs() - CACHE_TTL_SLACK_MS;
+}
 
 // Versioned key: pre-1.3.0 builds wrote a UsageData without `limits` to the
 // unversioned key. Sharing a key across versions let an older co-installed
@@ -81,9 +97,11 @@ export function activate(context: vscode.ExtensionContext) {
 	function scheduleNext() {
 		if (!windowFocused) { return; } // don't poll in background
 
+		// Back off after errors, but never poll faster than the configured interval.
+		const interval = pollIntervalMs();
 		const delay = errorCount === 0
-			? POLL_INTERVAL_MS
-			: BACKOFF_STEPS_MS[Math.min(errorCount - 1, BACKOFF_STEPS_MS.length - 1)];
+			? interval
+			: Math.max(interval, BACKOFF_STEPS_MS[Math.min(errorCount - 1, BACKOFF_STEPS_MS.length - 1)]);
 
 		timer = setTimeout(async () => {
 			await refresh();
@@ -94,7 +112,7 @@ export function activate(context: vscode.ExtensionContext) {
 	async function refresh() {
 		// Check global cache first — skip fetch if another window just did it
 		const cached = reviveCache(context.globalState.get<CacheEntry>(CACHE_KEY));
-		if (cached && (Date.now() - cached.fetchedAt) < CACHE_TTL_MS) {
+		if (cached && (Date.now() - cached.fetchedAt) < cacheTtlMs()) {
 			errorCount = cached.error ? errorCount : 0;
 			applyState(cached.data, cached.error);
 			return;
@@ -121,11 +139,12 @@ export function activate(context: vscode.ExtensionContext) {
 	if (cached) {
 		applyState(cached.data, cached.error);
 		const age = Date.now() - cached.fetchedAt;
-		if (age < CACHE_TTL_MS) {
+		const ttl = cacheTtlMs();
+		if (age < ttl) {
 			// Cache is fresh — delay first fetch to fill remaining TTL
 			timer = setTimeout(() => {
 				refresh().then(() => scheduleNext());
-			}, CACHE_TTL_MS - age);
+			}, ttl - age);
 		} else {
 			refresh().then(() => scheduleNext());
 		}
@@ -150,6 +169,13 @@ export function activate(context: vscode.ExtensionContext) {
 		panel.show(currentData, currentError);
 	});
 
+	// Apply a changed interval without a reload: restart the timer from now.
+	const onConfig = vscode.workspace.onDidChangeConfiguration((event) => {
+		if (!event.affectsConfiguration(`${CONFIG_SECTION}.refreshInterval`)) { return; }
+		if (timer) { clearTimeout(timer); timer = null; }
+		scheduleNext();
+	});
+
 	const refreshCmd = vscode.commands.registerCommand('claude-usage-monitor.refresh', async () => {
 		if (timer) { clearTimeout(timer); timer = null; }
 		// Force a real fetch by clearing the cache
@@ -163,6 +189,7 @@ export function activate(context: vscode.ExtensionContext) {
 		statusBar,
 		panel,
 		onFocus,
+		onConfig,
 		showPopup,
 		refreshCmd,
 	);

--- a/src/sessionPopover.ts
+++ b/src/sessionPopover.ts
@@ -276,6 +276,7 @@ function readPanelConfig() {
     warnT:    cfg.get<number>('warningThreshold', 60),
     errT:     cfg.get<number>('errorThreshold', 80),
     clockFmt: cfg.get<string>('clockFormat', 'auto'),
+    refreshS: cfg.get<number>('refreshInterval', 300),
   };
 }
 
@@ -297,7 +298,7 @@ interface PanelState {
  * user is mid-edit all survive a poll.
  */
 function buildFragments(data: UsageData | null, error: string | null, store: HistoryStore): PanelState {
-  const { warnT, errT, clockFmt } = readPanelConfig();
+  const { warnT, errT, clockFmt, refreshS } = readPanelConfig();
 
   // Burn rate per window, addressed by the same keys allWindows() uses.
   const burnByKey = new Map<string, string>();
@@ -528,6 +529,14 @@ function buildFragments(data: UsageData | null, error: string | null, store: His
 				<option value="12h"${sel(clockFmt, '12h')}>12-hour (7:44 PM)</option>
 				<option value="24h"${sel(clockFmt, '24h')}>24-hour (19:44)</option>
 			</select>
+		</div>
+		<div class="setting-row">
+			<span class="setting-label">Refresh interval <span class="info-icon" title="How often the usage API is polled, in seconds (minimum 60). Only while a VS Code window is focused; all windows share one cache. Raise this if the status bar shows HTTP 429: the usage endpoint has a small hourly budget per account.">ⓘ</span></span>
+			<div class="threshold-wrap">
+				<input type="number" class="setting-input" min="60" max="3600" step="30" value="${refreshS}"
+					onchange="updateSetting('claude-usage-monitor.refreshInterval', Number(this.value))">
+				<span class="threshold-pct">s</span>
+			</div>
 		</div>
 	</div>`;
 

--- a/src/sessionPopover.ts
+++ b/src/sessionPopover.ts
@@ -276,7 +276,7 @@ function readPanelConfig() {
     warnT:    cfg.get<number>('warningThreshold', 60),
     errT:     cfg.get<number>('errorThreshold', 80),
     clockFmt: cfg.get<string>('clockFormat', 'auto'),
-    refreshS: cfg.get<number>('refreshInterval', 300),
+    refreshS: cfg.get<number>('refreshInterval', 120),
   };
 }
 

--- a/src/sessionPopover.ts
+++ b/src/sessionPopover.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { UsageData, QuotaBucket, UsageLimit } from "./types";
+import { retryAtFromMessage } from "./usageClient";
 import {
   Burn,
   Store as HistoryStore,
@@ -60,9 +61,12 @@ function formatError(raw: string): { message: string; hint: string | null } {
     };
   }
   if (raw.includes('429')) {
+    const at = retryAtFromMessage(raw);
     return {
       message: 'HTTP 429 — Rate limited by Anthropic API.',
-      hint: 'The extension will retry automatically with backoff. No action needed.',
+      hint: at
+        ? `Waiting until <strong>${at}</strong>, as the API asked. Retrying sooner only keeps the limit full, so the panel will sit on the last reading until then.`
+        : 'The extension will retry automatically with backoff. No action needed.',
     };
   }
   if (raw.includes('timed out') || raw.includes('ECONNREFUSED') || raw.includes('ENOTFOUND')) {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { retryAtFromMessage } from './usageClient';
 import { UsageData } from './types';
 import {
 	allWindows,
@@ -181,8 +182,11 @@ export class StatusBarManager {
 			displayMsg = 'HTTP 403 — Account lacks API access.';
 			hint = 'Fix: ensure you are logged in to Claude Code with a Pro or Max subscription.';
 		} else if (message.includes('429')) {
+			const at = retryAtFromMessage(message);
 			displayMsg = 'HTTP 429 — Rate limited.';
-			hint = 'The extension will retry automatically.';
+			hint = at
+				? `Waiting until ${at}, as the API asked. Retrying sooner only keeps the limit full.`
+				: 'The extension will retry automatically.';
 		} else if (message.includes('timed out') || message.includes('ECONNREFUSED') || message.includes('ENOTFOUND')) {
 			displayMsg = 'Network error — cannot reach api.anthropic.com.';
 			hint = 'Fix: check your internet connection, then Ctrl+Shift+P → Claude: Refresh Usage.';

--- a/src/usageClient.ts
+++ b/src/usageClient.ts
@@ -7,11 +7,44 @@ import { QuotaBucket, UsageData, UsageLimit } from './types';
 
 const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
 const BETA_HEADER = 'oauth-2025-04-20';
+/** Guard against a nonsense header locking the status bar for days. */
+const MAX_RETRY_AFTER_S = 6 * 60 * 60;
 
 interface Credentials {
 	claudeAiOauth?: {
 		accessToken?: string;
 	};
+}
+
+/**
+ * Carries the server's own `retry-after` so the caller can wait exactly as
+ * long as it is told. Polling before that point keeps the rate limit window
+ * saturated, which is how a single 429 turns into a permanent lockout.
+ */
+export class UsageHttpError extends Error {
+	constructor(
+		message: string,
+		readonly statusCode: number | undefined,
+		readonly retryAfterMs: number | null,
+	) {
+		super(message);
+		this.name = 'UsageHttpError';
+	}
+}
+
+/** `retry-after` is either a delta in seconds or an HTTP date. Both are valid. */
+function parseRetryAfter(raw: string | string[] | undefined): number | null {
+	if (typeof raw !== 'string' || !raw.trim()) { return null; }
+	const seconds = Number(raw.trim());
+	if (Number.isFinite(seconds)) {
+		if (seconds < 0) { return null; }
+		return Math.min(seconds, MAX_RETRY_AFTER_S) * 1000;
+	}
+	const at = Date.parse(raw);
+	if (Number.isNaN(at)) { return null; }
+	const ms = at - Date.now();
+	if (ms <= 0) { return null; }
+	return Math.min(ms, MAX_RETRY_AFTER_S * 1000);
 }
 
 /**
@@ -64,7 +97,11 @@ function httpsGet(url: string, headers: Record<string, string>): Promise<string>
 				if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
 					resolve(body);
 				} else {
-					reject(new Error(`HTTP ${res.statusCode}: ${body}`));
+					reject(new UsageHttpError(
+						`HTTP ${res.statusCode}: ${body}`,
+						res.statusCode,
+						parseRetryAfter(res.headers['retry-after']),
+					));
 				}
 			});
 		});
@@ -143,7 +180,11 @@ export async function fetchUsageData(): Promise<UsageData> {
 			throw new Error('HTTP 403 — Forbidden: Your account may not have access to the usage API. Fix: make sure you are logged in to Claude Code with a valid Pro/Max subscription.');
 		}
 		if (msg.includes('HTTP 429')) {
-			throw new Error('HTTP 429 — Rate limited by Anthropic API. The extension will retry automatically with backoff.');
+			const retryAfterMs = err instanceof UsageHttpError ? err.retryAfterMs : null;
+			const wait = retryAfterMs === null
+				? 'The extension will retry automatically with backoff.'
+				: `Retrying in ${Math.max(1, Math.round(retryAfterMs / 60000))} min, as the API asked.`;
+			throw new UsageHttpError(`HTTP 429 — Rate limited by Anthropic API. ${wait}`, 429, retryAfterMs);
 		}
 		if (msg.includes('timed out') || msg.includes('ECONNREFUSED') || msg.includes('ENOTFOUND')) {
 			throw new Error(`Network error: ${msg}. Fix: check your internet connection and try running "Claude: Refresh Usage".`);

--- a/src/usageClient.ts
+++ b/src/usageClient.ts
@@ -6,6 +6,7 @@ import { execSync } from 'child_process';
 import { QuotaBucket, UsageData, UsageLimit } from './types';
 
 const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+const CLIENT_NAME = 'claude-usage-monitor';
 const BETA_HEADER = 'oauth-2025-04-20';
 /** Guard against a nonsense header locking the status bar for days. */
 const MAX_RETRY_AFTER_S = 6 * 60 * 60;
@@ -30,6 +31,19 @@ export class UsageHttpError extends Error {
 		super(message);
 		this.name = 'UsageHttpError';
 	}
+}
+
+/**
+ * Node sends no User-Agent of its own, and an unidentified caller appears to
+ * land in a much tighter rate limit bucket on this endpoint. Name ourselves
+ * honestly: this is not Claude Code and must not pretend to be.
+ */
+let userAgent = CLIENT_NAME;
+
+/** Called once at activation with the version from the extension manifest. */
+export function setUserAgent(version: string): void {
+	const clean = version.trim();
+	userAgent = clean ? `${CLIENT_NAME}/${clean}` : CLIENT_NAME;
 }
 
 /**
@@ -187,6 +201,7 @@ export async function fetchUsageData(): Promise<UsageData> {
 			'Authorization': `Bearer ${token}`,
 			'Content-Type': 'application/json',
 			'anthropic-beta': BETA_HEADER,
+			'User-Agent': userAgent,
 		});
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);

--- a/src/usageClient.ts
+++ b/src/usageClient.ts
@@ -32,6 +32,23 @@ export class UsageHttpError extends Error {
 	}
 }
 
+/**
+ * Marker in a 429 message naming when the extension will try again. The status
+ * bar and the panel rewrite these messages, and read it back with
+ * {@link retryAtFromMessage} so the wait survives that rewrite.
+ */
+export const RETRY_AT_PREFIX = 'Retry at ';
+
+function formatClock(at: Date): string {
+	return at.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+/** The clock time out of a 429 message, or null when the API did not say. */
+export function retryAtFromMessage(message: string): string | null {
+	const at = message.match(/Retry at ([^.]+)\./);
+	return at ? at[1] : null;
+}
+
 /** `retry-after` is either a delta in seconds or an HTTP date. Both are valid. */
 function parseRetryAfter(raw: string | string[] | undefined): number | null {
 	if (typeof raw !== 'string' || !raw.trim()) { return null; }
@@ -181,9 +198,11 @@ export async function fetchUsageData(): Promise<UsageData> {
 		}
 		if (msg.includes('HTTP 429')) {
 			const retryAfterMs = err instanceof UsageHttpError ? err.retryAfterMs : null;
+			// An absolute time, so the message stays true however long the
+			// error sits on screen. A relative one would age into a lie.
 			const wait = retryAfterMs === null
 				? 'The extension will retry automatically with backoff.'
-				: `Retrying in ${Math.max(1, Math.round(retryAfterMs / 60000))} min, as the API asked.`;
+				: `${RETRY_AT_PREFIX}${formatClock(new Date(Date.now() + retryAfterMs))}.`;
 			throw new UsageHttpError(`HTTP 429 — Rate limited by Anthropic API. ${wait}`, 429, retryAfterMs);
 		}
 		if (msg.includes('timed out') || msg.includes('ECONNREFUSED') || msg.includes('ENOTFOUND')) {


### PR DESCRIPTION
This started as "the extension gets stuck on `HTTP 429`" and ended somewhere less pleasant. The fixes below are real and worth having, but they do not bring the numbers back. The measurements are at the bottom, and they point at something you will want to decide on yourself. Related to #16.

## What this PR fixes

### 1. Honour the API's `retry-after`

A 429 says how long to wait, up to 3600 s. The backoff ignored it and retried every 4 to 16 minutes, so requests made during a block counted against the very window that had to drain. One 429 turned into a lockout lasting days: on my machine the extension had no successful fetch for over 24 hours, because it kept knocking.

- Parse `retry-after` (delta seconds or HTTP date, capped at 6 hours), carried on a typed `UsageHttpError`
- Wait exactly that long, over both the interval and the backoff
- Store the deadline in the cache every window shares, so one window being told to back off stops the others too
- `Claude: Refresh Usage` no longer punches through a block it cannot beat

This is the most important commit. With it, a block costs exactly one hour and then recovers on its own.

### 2. Only poll from a window that is actually focused

`windowFocused` started as a hardcoded `true`, corrected only by `onDidChangeWindowState`, which fires on a *change*. A window that activates while unfocused never gets that event and polls forever believing it is focused. Initialized from `vscode.window.state.focused`, and the activation fetch is skipped when unfocused so restoring a session does not fire every window at once before any of them has written the shared cache.

### 3. A configurable interval

`claude-usage-monitor.refreshInterval` (seconds, default unchanged at 120, min 60, max 3600), cache TTL follows it, applied without a reload, exposed in the panel's Settings tab.

### 4. Say when the extension will try again

The status bar and panel both overwrote the 429 message with a fixed "will retry automatically". They now name the time.

### 5. Send a User-Agent

Node sends none, so every request arrived unidentified. A client should name itself. **This does not fix the rate limiting**, see below. It is in here because it is correct, not because it helps.

## The measurements

Same machine, same account, same Node client, same token. Each test is the first call after a block expired, so the bucket is in the same state every time.

| `User-Agent` | Result |
|---|---|
| none (current released behaviour) | 429 within seconds, one hour block |
| `claude-usage-monitor/1.6.0` | 429 within seconds, one hour block |
| `claude-code/<version>` | 200, then roughly 6 to 12 calls per hour sustained |

Other findings while narrowing this down:

- The same token returns 200 on `/api/oauth/profile` while `/api/oauth/usage` returns 429, so the token is healthy and the limit is specific to this endpoint.
- Claude Code itself returned 200 on the very same endpoint at 14:28 and 14:29 while this extension was blocked from 14:20 to 15:20. Not an account-wide block.
- Header, protocol and query variations make no difference: `anthropic-beta`, `anthropic-version`, `x-app`, the billing attribution header, `x-stainless-*`, HTTP/1.1, `?at_wall=1&skip_spend=1`. Nine variants, all 429.
- No `ratelimit-*` headers on either a 200 or a 429. The 429 body is only `{"error":{"type":"rate_limit_error","message":"Rate limited. Please try again later."}}`.
- Claude Code barely needs this endpoint anyway: it reads `anthropic-ratelimit-unified-*` from the headers of ordinary `/v1/messages` responses and only falls back to `/api/oauth/usage`. A third-party tool has no such source.

## What that leaves

An honest third-party identity gets zero allowance on this endpoint. The only thing observed to work is presenting the first-party client's `User-Agent`, which is what #202 in Claude-Code-Usage-Monitor recommends and what several community tools appear to do.

I have deliberately not done that here. Shipping it would have every install misrepresent itself to Anthropic to get around an access control, on the user's own account, without them knowing. That is your call to make for your extension, not mine to make in a PR, so the facts are above and the decision is yours.

Worth noting that the upstream reports have gone nowhere: anthropics/claude-code#31021, #31637 and #30930 are all closed as not planned, with no response on what polling this endpoint is supposed to look like for tools built on Claude Code credentials. If there is a sanctioned way in, asking for one is probably more durable than any header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
